### PR TITLE
Allow order picking PDF to be returned

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -35,10 +35,10 @@ class Client
     }
 
     /**
-     * @param $method
-     * @param $uri
+     * @param string $method
+     * @param string $uri
      * @param  array  $options
-     * @return array
+     * @return array|string Array if the response was JSON, raw response body otherwise.
      */
     public function request(string $method, string $uri, array $options = [])
     {
@@ -46,8 +46,13 @@ class Client
 
         $contents = $response->getBody()->getContents();
 
-        $array = json_decode($contents, true);
+        if ($response->getHeader('Content-Type') === 'application/json') {
+            $array = json_decode($contents, true);
 
-        return (array) $array;
+            return (array) $array;
+        }
+        else {
+            return $contents;
+        }
     }
 }

--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -30,4 +30,17 @@ class Order extends Resource
     {
         return $this->client->request('PUT', "order/{$identifier}/accept");
     }
+
+    /**
+     * @param $identifier
+     * @param bool $file True if you want to have the PDF file returned.
+     * @return array
+     */
+    public function picking($identifier, $file = false)
+    {
+        $options = $file ? ['headers' => ['accept' => 'application/pdf']] : [];
+
+        return $this->client->request('GET', "order/{$identifier}/picking", $options);
+    }
+
 }


### PR DESCRIPTION
Only JSON responses (the default from the API) should be decoded, while others should be passed back raw and be left to the caller.