### PR TITLE
Added fluent method to use custom client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -3,8 +3,8 @@
 namespace ProductFlow\API;
 
 use GuzzleHttp\Client as GuzzleClient;
-use ProductFlow\API\Exceptions\ProductFlowException;
-use Psr\Http\Client\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\ClientInterface;
 
 class Client
 {
@@ -53,6 +53,7 @@ class Client
      * @param string $uri
      * @param  array  $options
      * @return array|string Array if the response was JSON, raw response body otherwise.
+     * @throws GuzzleException
      */
     public function request(string $method, string $uri, array $options = [])
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@ namespace ProductFlow\API;
 
 use GuzzleHttp\Client as GuzzleClient;
 use ProductFlow\API\Exceptions\ProductFlowException;
+use Psr\Http\Client\ClientInterface;
 
 class Client
 {
@@ -32,6 +33,19 @@ class Client
                 'X-Company-Id' => $companyId
             ]
         ]);
+    }
+
+    /**
+     * Use own custom client. This can be useful for testing, additional logging, setting custom user agent etc.
+     *
+     * @param ClientInterface $client
+     * @return $this
+     */
+    public function useClient(ClientInterface $client) : self
+    {
+        $this->client = $client;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
I was hesistant to change anything on the constructor for BC reasons. This PR implementation is not the most ideal, but the only realistic option to not break other installations.

It adds the option for changing the underlying client as Cloudfront favors requests with user agents and (for instance) a handler stack can now be attached to the client for logging, default parameters and other middlewares.