### PR TITLE
Rewind the response body

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -59,6 +59,7 @@ class Client
     {
         $response = $this->client->request($method, $uri, $options);
 
+        $response->getBody()->rewind();
         $contents = $response->getBody()->getContents();
 
         // fallback to application/json as this is, apart from 1 call, the return type


### PR DESCRIPTION
In case a logger has been injected earlier, the contents of the response body can be logged. 
Therefor the response body should rewind to the beginning before getting the contents.